### PR TITLE
hotfix : 実機で実行不能な問題を修正

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.0.0'
     annotationProcessor 'androidx.lifecycle:lifecycle-compiler:2.0.0'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.robolectric:robolectric:4.1'

--- a/app/src/main/java/com/imaginaryrhombus/proctimer/ui/timerpicker/TimerPickerFragment.kt
+++ b/app/src/main/java/com/imaginaryrhombus/proctimer/ui/timerpicker/TimerPickerFragment.kt
@@ -29,13 +29,6 @@ class TimerPickerFragment : DialogFragment() {
     /// ダイアログを閉じるときに設定するようの値,秒.
     private lateinit var secondsString: String
 
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        return inflater.inflate(R.layout.timer_picker_fragment, container, false)
-    }
-
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         super.onCreateDialog(savedInstanceState)
 
@@ -111,11 +104,4 @@ class TimerPickerFragment : DialogFragment() {
 
         return builder.create()
     }
-
-    override fun onStop() {
-        super.onStop()
-
-
-    }
-
 }


### PR DESCRIPTION
## 修正内容

- ダイアログの onCreateView() の実装を削除
  - この実装が残っているとダイアログとして生成した際にクラッシュする.
  - ref : http://y-anz-m.blogspot.com/2011/12/androiddialogfragment.html (情報が古いが参考になった.)