### PR TITLE
[Hotfix] Circle CI が最新の Android API 28 Docker イメージで実行に失敗するのを暫定修正

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
     build:
         working_directory : ~/code
         docker:
-            - image: circleci/android:api-28
+            - image: circleci/android:api-28@sha256:b7f3794130dbfedb987d4f4940d5ae7996d45b95
         enviroment:
             JVM_OPTS : -Xmx4G
         steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
     build:
         working_directory : ~/code
         docker:
-            - image: circleci/android:api-28@sha256:b7f3794130dbfedb987d4f4940d5ae7996d45b95
+            - image: circleci/android:api-28@sha256:e87528d81a9e762d80232e1a6c32a3f374195a7ffa0aa3eb2a594bc166d6ae67
         enviroment:
             JVM_OPTS : -Xmx4G
         steps:


### PR DESCRIPTION
## 確認事項

Android API 28 のイメージのどこが悪いかちょっと見ておく。