### PR TITLE
gitignore 更新

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # Built application files
 *.apk
 *.ap_
+*.aab
 
 # Files for the ART/Dalvik VM
 *.dex


### PR DESCRIPTION
.aab ファイル(アプリバンドル)ファイルを git の管理下に置かないように修正(生成物なので)