### PR TITLE
フィールドの型を調整、テスト追加とそれによって判明したバグの修正

### DIFF
--- a/app/src/main/java/com/imaginaryrhombus/proctimer/ui/timer/MultiTimerModel.kt
+++ b/app/src/main/java/com/imaginaryrhombus/proctimer/ui/timer/MultiTimerModel.kt
@@ -68,8 +68,7 @@ class MultiTimerModel(context: Context) {
         timers.clear()
         if (restoreTimerPreferences().not()) {
             for (index in 0 until TimerConstants.TIMER_DEFAULT_COUNTS) {
-                val timer = createTimerModel()
-                timers.add(timer)
+                timers.add(createTimerModel())
             }
             saveTimerPreferences()
         }

--- a/app/src/main/java/com/imaginaryrhombus/proctimer/ui/timer/MultiTimerModel.kt
+++ b/app/src/main/java/com/imaginaryrhombus/proctimer/ui/timer/MultiTimerModel.kt
@@ -117,10 +117,11 @@ class MultiTimerModel(context: Context) {
      *
      */
     fun getTimers(count: Int, includeActive: Boolean = false): List<TimerModel?> {
-        val retCount = if (count.sign == -1) timers.size else count
+        // includeActive.not のときは戦闘タイマーの数分差し引いた数を全体の数として扱う.
+        val timersCount = if (includeActive) timers.size else timers.size - 1
+        val retCount = if (count.sign == -1) timersCount else count
         val ret = MutableList<TimerModel?>(retCount) { null }
-        val initIndex = if (includeActive) 0 else 1
-        for (i in initIndex until retCount) {
+        for (i in 0 until min(timersCount, retCount)) {
             val timerIndex = if (includeActive) i else i + 1
             ret[i] = getTimer(timerIndex)
         }

--- a/app/src/main/java/com/imaginaryrhombus/proctimer/ui/timer/TimerViewModel.kt
+++ b/app/src/main/java/com/imaginaryrhombus/proctimer/ui/timer/TimerViewModel.kt
@@ -43,7 +43,12 @@ class TimerViewModel(private val app: Application) : AndroidViewModel(app) {
     /**
      * 準備中のタイマーのテキスト.
      */
-    val nextTimerStrings = MutableList(displayNextTimerCount) { MutableLiveData<String>() }
+    private val _nextTimerStrings = MutableList(displayNextTimerCount) { MutableLiveData<String>() }
+
+    val nextTimerStrings : List<MutableLiveData<String>>
+    get() {
+        return _nextTimerStrings.toList()
+    }
 
     /**
      * タイマーが変更されたときのリスナー.
@@ -122,12 +127,12 @@ class TimerViewModel(private val app: Application) : AndroidViewModel(app) {
      */
     private fun updateTimerText() {
         // 予めタイマーが無い文字列で初期化してからタイマーを取得して文字列を更新する.
-        nextTimerStrings.forEach {
+        _nextTimerStrings.forEach {
             it.postValue(app.applicationContext.getString(R.string.timer_invalid_text))
         }
 
-        val timers = multiTimerModel.getTimers(nextTimerStrings.size)
-        nextTimerStrings.forEachIndexed { index, timerText ->
+        val timers = multiTimerModel.getTimers(_nextTimerStrings.size)
+        _nextTimerStrings.forEachIndexed { index, timerText ->
             timers[index]?.let {
                 timerText.postValue(createTimerStringFromSeconds(it.seconds.value!!))
             }

--- a/app/src/main/java/com/imaginaryrhombus/proctimer/ui/timer/TimerViewModel.kt
+++ b/app/src/main/java/com/imaginaryrhombus/proctimer/ui/timer/TimerViewModel.kt
@@ -45,7 +45,7 @@ class TimerViewModel(private val app: Application) : AndroidViewModel(app) {
      */
     private val _nextTimerStrings = MutableList(displayNextTimerCount) { MutableLiveData<String>() }
 
-    val nextTimerStrings : List<MutableLiveData<String>>
+    val nextTimerStrings: List<MutableLiveData<String>>
     get() {
         return _nextTimerStrings.toList()
     }

--- a/app/src/test/java/com/imaginaryrhombus/proctimer/MultiTimerModelTest.kt
+++ b/app/src/test/java/com/imaginaryrhombus/proctimer/MultiTimerModelTest.kt
@@ -7,6 +7,7 @@ import com.imaginaryrhombus.proctimer.ui.timer.MultiTimerModel
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -46,6 +47,66 @@ class MultiTimerModelTest {
             assertNotNull(it)
             assertEquals(it?.seconds?.value, TimerConstants.TIMER_DEFAULT_SECONDS)
             assertEquals(it?.defaultSeconds, TimerConstants.TIMER_DEFAULT_SECONDS)
+        }
+    }
+
+    /**
+     * タイマー取得の挙動を確認する.
+     */
+    @Test
+    fun testGetTimer() {
+        sharedPreferences.edit().clear()
+
+        val multiTimerModel = MultiTimerModel(testActivity)
+
+        multiTimerModel.addTimer()
+        multiTimerModel.setActiveTimerSeconds(30.0f)
+        multiTimerModel.next()
+        multiTimerModel.setActiveTimerSeconds(60.0f)
+        multiTimerModel.next()
+        multiTimerModel.setActiveTimerSeconds(90.0f)
+        multiTimerModel.next()
+
+        /**
+         * この時点で、以下のような並びになっているはず.
+         * [30.0f], [60.0f], [90.0f]
+         */
+
+        multiTimerModel.getTimers(-1, true).run {
+            assertEquals(size, 3)
+            assertNotNull(get(0))
+            assertNotNull(get(1))
+            assertNotNull(get(2))
+            assertEquals(get(0)?.seconds?.value, 30.0f)
+            assertEquals(get(1)?.seconds?.value, 60.0f)
+            assertEquals(get(2)?.seconds?.value, 90.0f)
+            assertEquals(get(0)?.defaultSeconds, 30.0f)
+            assertEquals(get(1)?.defaultSeconds, 60.0f)
+            assertEquals(get(2)?.defaultSeconds, 90.0f)
+        }
+
+        multiTimerModel.getTimers(3, true).run {
+            assertEquals(size, 3)
+            assertNotNull(get(0))
+            assertNotNull(get(1))
+            assertNotNull(get(2))
+            assertEquals(get(0)?.seconds?.value, 30.0f)
+            assertEquals(get(1)?.seconds?.value, 60.0f)
+            assertEquals(get(2)?.seconds?.value, 90.0f)
+            assertEquals(get(0)?.defaultSeconds, 30.0f)
+            assertEquals(get(1)?.defaultSeconds, 60.0f)
+            assertEquals(get(2)?.defaultSeconds, 90.0f)
+        }
+
+        multiTimerModel.getTimers(3).run {
+            assertEquals(size, 3)
+            assertNotNull(get(0))
+            assertNotNull(get(1))
+            assertNull(get(2))
+            assertEquals(get(0)?.seconds?.value, 60.0f)
+            assertEquals(get(1)?.seconds?.value, 90.0f)
+            assertEquals(get(0)?.defaultSeconds, 60.0f)
+            assertEquals(get(1)?.defaultSeconds, 90.0f)
         }
     }
 


### PR DESCRIPTION
## 修正内容

- MutableList(コミットログでは MutableLiveData と書いているが誤り) を返していて、外から要素数が操作される可能性があったのを修正

## 別件の修正内容

以前と違うタイマーの表示になっていたので、確認したところ、 MultiTimerModel.getTimers() の返り値が装丁と異なることになっていたので、テストコードを追加して、更に修正.