### PR TITLE
Firebase Crashlytics 導入.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,15 +9,25 @@ defaults: &defaults
     JVM_OPTS: -Xmx4G
 
 jobs:
-    decode_json:
+    checkout:
         <<: *defaults
         steps:
             - checkout
+            - persist_to_workspace:
+                root: .
+                paths:
+                    - .
+
+    decode_json:
+        <<: *defaults
+        steps:
+            - attach_workspace:
+                at: .
             - run:
                 name: Decode json
                 command: echo $GOOGLE_SERVICES_JSON | base64 --decode --ignore-garbage > app/google-services.json
             - persist_to_workspace:
-                root: ~/code
+                root: .
                 paths:
                     - .
 
@@ -75,7 +85,7 @@ jobs:
             - store_test_results:
                 path: app/build/test-results
             - persist_to_workspace:
-                root: ~/code
+                root: .
                 paths:
                     - .
 
@@ -92,7 +102,7 @@ jobs:
                 path: app/build/outputs/apk/app-debug.apk
                 destination: app-debug.apk
             - persist_to_workspace:
-                root: ~/code
+                root: .
                 paths:
                     - .
 
@@ -109,7 +119,7 @@ jobs:
                 path: app/build/outputs/bundle/release/app.aab
                 destination: app.aab
             - persist_to_workspace:
-                root: ~/code
+                root: .
                 paths:
                     - .
 
@@ -117,29 +127,22 @@ workflows:
     version: 2
     build:
         jobs:
-            - decode_json
-            - download_dependencies
+            - checkout
+            - decode_json:
+                requires:
+                    - checkout
+            - download_dependencies:
+                requires:
+                    - checkout
             - build:
                 requires:
                     - decode_json
                     - download_dependencies
-                filters:
-                    branches:
-                        only:
-                            - master
-                            - develop
-                            - /feature\/.*/
-                            - /hotfix\/.*/
             - check:
                 requires:
-                    - decode_json
-                    - download_dependencies
                     - build
             - deploy:
                 requires:
-                    - decode_json
-                    - download_dependencies
-                    - build
                     - check
                 filters:
                     branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,8 @@ workflows:
                         only:
                             - master
                             - develop
+                            - /feature\/.*/
+                            - /hotfix\/.*/
             - check:
                 requires:
                     - decode_json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,14 +45,14 @@ jobs:
                 command: sudo chmod +x ./gradlew
             - restore_cache:
                 keys:
-                    - jars-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
+                    - jars-cache-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
             - run:
                 name: Download Dependencies
                 command: ./gradlew androidDependencies
             - save_cache:
                 paths:
                     - ~/.gradle
-                key: jars-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
+                key: jars-cache-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
             # Run Tests and store results.
             - run:
                 name: Run Tests
@@ -84,14 +84,14 @@ jobs:
                 command: sudo chmod +x ./gradlew
             - restore_cache:
                 keys:
-                    - jars-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
+                    - jars-cache-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
             - run:
                 name: Download Dependencies
                 command: ./gradlew androidDependencies
             - save_cache:
                 paths:
                     - ~/.gradle
-                key: jars-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
+                key: jars-cache-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
             # build
             - run:
                 name: Build
@@ -115,14 +115,14 @@ jobs:
                 command: sudo chmod +x ./gradlew
             - restore_cache:
                 keys:
-                    - jars-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
+                    - jars-cache-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
             - run:
                 name: Download Dependencies
                 command: ./gradlew androidDependencies
             - save_cache:
                 paths:
                     - ~/.gradle
-                key: jars-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
+                key: jars-cache-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
             # build
             - run:
                 name: Build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,15 @@ defaults: &defaults
     JVM_OPTS: -Xmx4G
 
 jobs:
+    decode_json:
+        <<: *defaults
+        steps:
+            - checkout
+            - run:
+                name: Decode json
+                command: echo $GOOGLE_SERVICES_JSON | base64 --decode --ignore-garbage > ${HOME}/${CIRCLE_PROJECT_REPONAME}/app/google-services.json
+
+
     check:
         <<: *defaults
         steps:
@@ -19,7 +28,9 @@ jobs:
                     - gem-cache-v1-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
                     - gem-cache-v1-{{ arch }}-{{ .Branch }}
                     - gem-cache-v1
-            - run: bundle install --path vendor/bundle --clean --jobs=2 --retry=3
+            - run:
+                name: Bundle Install
+                command: bundle install --path vendor/bundle --clean --jobs=2 --retry=3
             - save_cache:
                 key: gem-cache-v1-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
                 paths:
@@ -122,7 +133,10 @@ workflows:
     version: 2
     build:
         jobs:
-            - build
+            - decode_json
+            - build:
+                requires:
+                    - decode_json
             - check:
                 requires:
                     - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,10 @@ jobs:
             - run:
                 name: Decode json
                 command: echo $GOOGLE_SERVICES_JSON | base64 --decode --ignore-garbage > app/google-services.json
-
+            - persist_to_workspace:
+                root: ~/code
+                paths:
+                    - .
 
     check:
         <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,13 +36,13 @@ jobs:
         steps:
             - attach_workspace:
                 at: .
+            - restore_cache:
+                keys:
+                    - jars-cache-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
             # add permissison avoid failre
             - run:
                 name: Chmod permissions
                 command: sudo chmod +x ./gradlew
-            - restore_cache:
-                keys:
-                    - jars-cache-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
             - run:
                 name: Download Dependencies
                 command: ./gradlew androidDependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
             - checkout
             - run:
                 name: Decode json
-                command: echo $GOOGLE_SERVICES_JSON | base64 --decode --ignore-garbage > ${HOME}/${CIRCLE_PROJECT_REPONAME}/app/google-services.json
+                command: echo $GOOGLE_SERVICES_JSON | base64 --decode --ignore-garbage > app/google-services.json
 
 
     check:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,8 @@ jobs:
     check:
         <<: *defaults
         steps:
-            - checkout
+            - attach_workspace:
+                at: .
             # for danger
             - restore_cache:
                 keys:
@@ -75,7 +76,8 @@ jobs:
     build:
         <<: *defaults
         steps:
-            - checkout
+            - attach_workspace:
+                at: .
             # add permissison avoid failre
             - run:
                 name: Chmod permissions
@@ -105,7 +107,8 @@ jobs:
     deploy:
         <<: *defaults
         steps:
-            - checkout
+            - attach_workspace:
+                at: .
             # add permissison avoid failre
             - run:
                 name: Chmod permissions
@@ -140,11 +143,18 @@ workflows:
             - build:
                 requires:
                     - decode_json
+                filters:
+                    branches:
+                        only:
+                            - master
+                            - develop
             - check:
                 requires:
+                    - decode_json
                     - build
             - deploy:
                 requires:
+                    - decode_json
                     - build
                     - check
                 filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,10 @@ jobs:
                 key: gem-cache-v1-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
                 paths:
                     - vendor/bundle
+            # add permissison avoid failre
+            - run:
+                name: Chmod permissions
+                command: sudo chmod +x ./gradlew
             # Run Tests and store results.
             - run:
                 name: Run Tests
@@ -94,6 +98,10 @@ jobs:
         steps:
             - attach_workspace:
                 at: .
+            # add permissison avoid failre
+            - run:
+                name: Chmod permissions
+                command: sudo chmod +x ./gradlew
             # build
             - run:
                 name: Build
@@ -111,6 +119,10 @@ jobs:
         steps:
             - attach_workspace:
                 at: .
+            # add permissison avoid failre
+            - run:
+                name: Chmod permissions
+                command: sudo chmod +x ./gradlew
             # build
             - run:
                 name: Build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,26 @@ jobs:
                 paths:
                     - .
 
+    download_dependencies:
+        <<: *defaults
+        steps:
+            - attach_workspace:
+                at: .
+            # add permissison avoid failre
+            - run:
+                name: Chmod permissions
+                command: sudo chmod +x ./gradlew
+            - restore_cache:
+                keys:
+                    - jars-cache-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
+            - run:
+                name: Download Dependencies
+                command: ./gradlew androidDependencies
+            - save_cache:
+                paths:
+                    - ~/.gradle
+                key: jars-cache-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
+
     check:
         <<: *defaults
         steps:
@@ -39,20 +59,6 @@ jobs:
                 key: gem-cache-v1-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
                 paths:
                     - vendor/bundle
-            # add permissison avoid failre
-            - run:
-                name: Chmod permissions
-                command: sudo chmod +x ./gradlew
-            - restore_cache:
-                keys:
-                    - jars-cache-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
-            - run:
-                name: Download Dependencies
-                command: ./gradlew androidDependencies
-            - save_cache:
-                paths:
-                    - ~/.gradle
-                key: jars-cache-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
             # Run Tests and store results.
             - run:
                 name: Run Tests
@@ -78,20 +84,6 @@ jobs:
         steps:
             - attach_workspace:
                 at: .
-            # add permissison avoid failre
-            - run:
-                name: Chmod permissions
-                command: sudo chmod +x ./gradlew
-            - restore_cache:
-                keys:
-                    - jars-cache-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
-            - run:
-                name: Download Dependencies
-                command: ./gradlew androidDependencies
-            - save_cache:
-                paths:
-                    - ~/.gradle
-                key: jars-cache-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
             # build
             - run:
                 name: Build
@@ -109,20 +101,6 @@ jobs:
         steps:
             - attach_workspace:
                 at: .
-            # add permissison avoid failre
-            - run:
-                name: Chmod permissions
-                command: sudo chmod +x ./gradlew
-            - restore_cache:
-                keys:
-                    - jars-cache-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
-            - run:
-                name: Download Dependencies
-                command: ./gradlew androidDependencies
-            - save_cache:
-                paths:
-                    - ~/.gradle
-                key: jars-cache-v1-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
             # build
             - run:
                 name: Build
@@ -140,9 +118,11 @@ workflows:
     build:
         jobs:
             - decode_json
+            - download_dependencies
             - build:
                 requires:
                     - decode_json
+                    - download_dependencies
                 filters:
                     branches:
                         only:
@@ -153,10 +133,12 @@ workflows:
             - check:
                 requires:
                     - decode_json
+                    - download_dependencies
                     - build
             - deploy:
                 requires:
                     - decode_json
+                    - download_dependencies
                     - build
                     - check
                 filters:

--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,6 @@ fabric.properties
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 
 # End of https://www.gitignore.io/api/kotlin,androidstud
+
+# Don't commit sensitive infomation
+google-services.json

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: "org.jlleitschuh.gradle.ktlint"
+apply plugin: 'com.google.gms.google-services'
 
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 
@@ -53,6 +54,7 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.0.0'
     implementation 'com.google.code.gson:gson:2.8.5'
+    implementation 'com.google.firebase:firebase-core:16.0.1'
     kapt 'androidx.lifecycle:lifecycle-compiler:2.0.0'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.robolectric:robolectric:4.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,8 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: "org.jlleitschuh.gradle.ktlint"
 apply plugin: 'com.google.gms.google-services'
+apply plugin: 'kotlin-kapt'
+apply plugin: 'io.fabric'
 
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 
@@ -54,7 +56,9 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.0.0'
     implementation 'com.google.code.gson:gson:2.8.5'
-    implementation 'com.google.firebase:firebase-core:16.0.1'
+    implementation 'com.google.firebase:firebase-core:16.0.6'
+    implementation 'com.google.firebase:firebase-crash:16.2.1'
+    implementation 'com.crashlytics.sdk.android:crashlytics:2.9.8'
     kapt 'androidx.lifecycle:lifecycle-compiler:2.0.0'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.robolectric:robolectric:4.1'

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.3.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:6.3.1"
+        classpath 'com.google.gms:google-services:4.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -9,12 +9,16 @@ buildscript {
         maven {
             url "https://plugins.gradle.org/m2/"
         }
+        maven {
+            url 'https://maven.fabric.io/public'
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:6.3.1"
-        classpath 'com.google.gms:google-services:4.0.1'
+        classpath 'com.google.gms:google-services:4.2.0'
+        classpath 'io.fabric.tools:gradle:1.27.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -25,6 +29,9 @@ allprojects {
     repositories {
         google()
         jcenter()
+        maven {
+            url 'https://maven.fabric.io/public'
+        }
     }
 }
 


### PR DESCRIPTION
## TODO
- [x] Circle CI でのビルドが通るように修正する.
  - [x] google-services.json を git 管理下に置かずに CI に適用する.

## 概要

fixes #43 

クラッシュレポートを収集するため Firebase Crashlytics を導入する。