### PR TITLE
ktlint で警告が出る 100 文字目にラインを引くよう設定変更

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <option name="SOFT_MARGINS" value="100" />
     <JetCodeStyleSettings>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>


### PR DESCRIPTION
コーディングしていると割と超えてしまうことが多いので、目安としてわかりやすくするための変更