### PR TITLE
タイマーのタップターゲットのサイズをより大きく修正

### DIFF
--- a/app/src/main/res/layout/timer_fragment.xml
+++ b/app/src/main/res/layout/timer_fragment.xml
@@ -22,7 +22,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
             android:text="@{timerViewModel.currentTimerText, default=@string/timer_default_text}"
-            android:textSize="30sp"/>
+            android:textSize="42sp"/>
         <TextView
             android:id="@+id/nextTimerText1"
             android:layout_width="wrap_content"


### PR DESCRIPTION
Google Play Console での警告が出ていたのでユーザビリティ向上のためにも修正