### PR TITLE
Firebase Crashlytics を 2.9.9 に更新

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-core:16.0.7'
     implementation 'com.google.firebase:firebase-crash:16.2.1'
     implementation 'com.google.firebase:firebase-config:16.1.3'
-    implementation 'com.crashlytics.sdk.android:crashlytics:2.9.8'
+    implementation 'com.crashlytics.sdk.android:crashlytics:2.9.9'
     kapt 'androidx.lifecycle:lifecycle-compiler:2.0.0'
     testImplementation 'androidx.test:core:1.1.0'
     testImplementation 'junit:junit:4.12'


### PR DESCRIPTION
クラッシュを追跡できなくなっていたので.