### PR TITLE
TimerPickerFragment がいくつかのクラッシュ原因になっていたのを修正

### DIFF
--- a/app/src/main/java/com/imaginaryrhombus/proctimer/ui/timerpicker/TimerPickerFragment.kt
+++ b/app/src/main/java/com/imaginaryrhombus/proctimer/ui/timerpicker/TimerPickerFragment.kt
@@ -74,6 +74,8 @@ class TimerPickerFragment : DialogFragment() {
                 value = displayedValues.run {
                     indexOf(find { it == initMinutesString } ?: first())
                 }
+                isSaveEnabled = false
+                isSaveFromParentEnabled = false
             }
 
             secondsPicker.apply {
@@ -84,6 +86,8 @@ class TimerPickerFragment : DialogFragment() {
                 value = displayedValues.run {
                     indexOf(find { it == initSecondsString } ?: first())
                 }
+                isSaveEnabled = false
+                isSaveFromParentEnabled = false
             }
         }
 


### PR DESCRIPTION
それぞれの Picker に isSaveEnabled , isSaveFromParentEnabled = false を設定し、クラッシュを回避。
link : https://stackoverflow.com/questions/31030704/android-numberpicker-index-outofbounds-rotation
