### PR TITLE
Instant Apps として実行したときにプライバシーポリシーをストアを参照するようにトーストを出すように変更

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,6 +61,7 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.0.0'
     implementation 'com.google.android.material:material:1.0.0'
+    implementation 'com.google.android.instantapps:instantapps:1.1.0'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'com.google.firebase:firebase-core:16.0.7'
     implementation 'com.google.firebase:firebase-crash:16.2.1'

--- a/app/src/main/java/com/imaginaryrhombus/proctimer/TimerActivity.kt
+++ b/app/src/main/java/com/imaginaryrhombus/proctimer/TimerActivity.kt
@@ -12,6 +12,7 @@ import android.widget.Toast
 import androidx.appcompat.app.ActionBarDrawerToggle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.GravityCompat
+import com.google.android.gms.common.wrappers.InstantApps
 import com.imaginaryrhombus.proctimer.application.TimerRemoteConfigClientInterface
 import com.imaginaryrhombus.proctimer.application.TimerSharedPreferencesComponent
 import com.imaginaryrhombus.proctimer.application.UpdateChecker
@@ -108,22 +109,29 @@ class TimerActivity : AppCompatActivity(),
     }
 
     private fun openPrivacyPolicy() {
-        val privacyPolicyUrl = remoteConfigClient.privacyPolicyUrl
-        if (privacyPolicyUrl.isNotEmpty()) {
-            val intent = Intent(
-                Intent.ACTION_VIEW,
-                Uri.parse(
-                    privacyPolicyUrl
-                )
-            )
-            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            startActivity(intent)
-        } else {
+        if (InstantApps.isInstantApp(applicationContext)) {
             Toast.makeText(
-                this, getString(R.string.privacy_policy_offline),
-                Toast.LENGTH_SHORT
+                this, getString(R.string.instant_apps_privacy_toast), Toast.LENGTH_SHORT
             )
                 .show()
+        } else {
+            val privacyPolicyUrl = remoteConfigClient.privacyPolicyUrl
+            if (privacyPolicyUrl.isNotEmpty()) {
+                val intent = Intent(
+                    Intent.ACTION_VIEW,
+                    Uri.parse(
+                        privacyPolicyUrl
+                    )
+                )
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                startActivity(intent)
+            } else {
+                Toast.makeText(
+                    this, getString(R.string.privacy_policy_offline),
+                    Toast.LENGTH_SHORT
+                )
+                    .show()
+            }
         }
     }
 

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -36,4 +36,7 @@
     <string name="privacy_policy_offline">Could not get the privacy policy posting address.
         Make sure the device is connected to the network.
     </string>
+    <string name="instant_apps_privacy_toast">Please refer to the latest privacy policy from the store page during
+        trial.
+    </string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,4 +31,5 @@
     <string name="button_theme_change">変更</string>
     <string name="button_move_to_store">ストアに移動</string>
     <string name="privacy_policy_offline">プライバシーポリシー掲載先が取得できませんでした。デバイスがネットワークに接続されていることを確認してください。</string>
+    <string name="instant_apps_privacy_toast">試用中はストアのページより最新版のプライバシーポリシーを参照してください。</string>
 </resources>


### PR DESCRIPTION
Firebase Remote Config が Instamt Apps だと正常に動作しないため