### PR TITLE
起動直後、タイマーの通知が行われないことがあったのを修正

### DIFF
--- a/app/src/main/java/com/imaginaryrhombus/proctimer/ui/timer/MultiTimerModel.kt
+++ b/app/src/main/java/com/imaginaryrhombus/proctimer/ui/timer/MultiTimerModel.kt
@@ -12,7 +12,7 @@ import java.util.LinkedList
  */
 class MultiTimerModel(
     private val timerSharedPreferencesComponent: TimerSharedPreferencesComponent
-) {
+) : TimerModel.OnEndedListener {
 
     /**
      * タイマー切り替わり時のリスナーインターフェース.
@@ -166,20 +166,12 @@ class MultiTimerModel(
      * @note この関数を通さないと終了時リスナーが働かない.
      */
     private fun createTimerModel(): TimerModel {
-        return TimerModel().apply {
-            onEndListener = object : TimerModel.OnEndedListener {
-                override fun onEnd() {
-                    onTimerEnd()
-                }
-            }
+        return TimerModel(this).apply {
             setSeconds(TimerConstants.TIMER_DEFAULT_SECONDS)
         }
     }
 
-    /**
-     * タイマー終了時の動作.
-     */
-    private fun onTimerEnd() {
+    override fun onEnd() {
         onEachTimerEndedListener?.onEnd()
     }
 
@@ -199,7 +191,7 @@ class MultiTimerModel(
     private fun restoreTimerPreferences() {
         _linkedTimerList.clear()
         timerSharedPreferencesComponent.timerSecondsList.forEach {
-            _linkedTimerList.addLast(TimerModel().apply { setSeconds(it) })
+            _linkedTimerList.addLast(createTimerModel().apply { setSeconds(it) })
         }
     }
 

--- a/app/src/main/java/com/imaginaryrhombus/proctimer/ui/timer/TimerModel.kt
+++ b/app/src/main/java/com/imaginaryrhombus/proctimer/ui/timer/TimerModel.kt
@@ -5,8 +5,9 @@ import androidx.lifecycle.MutableLiveData
 
 /**
  * 一つ一つのタイマー用モデル.
+ * @param onEndListener 子のタイマー終了時のコールバック.
  */
-class TimerModel {
+class TimerModel(var onEndListener: OnEndedListener? = null) {
 
     /**
      * タイマー終了時リスナー.
@@ -46,11 +47,6 @@ class TimerModel {
      */
     val isEnded: Boolean
     get() = _seconds <= 0.0f
-
-    /**
-     * 終了時のコールバック.
-     */
-    var onEndListener: OnEndedListener? = null
 
     /**
      * 秒数を設定する.

--- a/app/src/test/java/com/imaginaryrhombus/proctimer/MultiTimerModelTest.kt
+++ b/app/src/test/java/com/imaginaryrhombus/proctimer/MultiTimerModelTest.kt
@@ -7,6 +7,7 @@ import com.imaginaryrhombus.proctimer.application.TimerSharedPreferencesComponen
 import com.imaginaryrhombus.proctimer.constants.TimerConstants
 import com.imaginaryrhombus.proctimer.ui.timer.MultiTimerModel
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -118,6 +119,18 @@ class MultiTimerModelTest : AutoCloseKoinTest() {
         for (index in 0 until timers.size) {
             assertEquals(timers[index].seconds.value, timers2[index].seconds.value)
             assertEquals(timers[index].defaultSeconds, timers2[index].defaultSeconds)
+        }
+    }
+
+    /**
+     * リスナーが未登録でないことを保証する.
+     */
+    @Test
+    fun testListener() {
+        val multiTimerModel = MultiTimerModel(get())
+
+        multiTimerModel.timerList.forEach {
+            assertNotNull(it.onEndListener)
         }
     }
 }


### PR DESCRIPTION
fixes #128 

## 原因

リスナーの登録が正常に行われないフローが存在した。