### PR TITLE
CI 時のみ、 allWraningsAsErrors を有効化

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,7 +31,7 @@ android {
         enabled = true
     }
     kotlinOptions {
-        allWarningsAsErrors = true
+        allWarningsAsErrors = "$System.env.CI"
     }
     testOptions {
         unitTests {


### PR DESCRIPTION
開発しにくくなるため