### PR TITLE
Toast の代わりに Snack Bar を使用するよう変更

### DIFF
--- a/app/src/main/java/com/imaginaryrhombus/proctimer/TimerActivity.kt
+++ b/app/src/main/java/com/imaginaryrhombus/proctimer/TimerActivity.kt
@@ -9,12 +9,12 @@ import android.os.Bundle
 import android.os.PersistableBundle
 import android.view.MenuItem
 import android.view.View
-import android.widget.Toast
 import androidx.appcompat.app.ActionBarDrawerToggle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.view.GravityCompat
 import com.google.android.gms.common.wrappers.InstantApps
+import com.google.android.material.snackbar.Snackbar
 import com.imaginaryrhombus.proctimer.application.TimerRemoteConfigClientInterface
 import com.imaginaryrhombus.proctimer.application.TimerSharedPreferencesComponent
 import com.imaginaryrhombus.proctimer.application.UpdateChecker
@@ -99,10 +99,11 @@ class TimerActivity :
 
     private fun openPrivacyPolicy() {
         if (InstantApps.isInstantApp(applicationContext)) {
-            Toast.makeText(
-                this, getString(R.string.instant_apps_privacy_toast), Toast.LENGTH_SHORT
-            )
-                .show()
+            Snackbar.make(
+                findViewById(R.id.frame),
+                R.string.instant_apps_privacy_toast,
+                Snackbar.LENGTH_SHORT
+            ).show()
         } else {
             val privacyPolicyUrl = remoteConfigClient.privacyPolicyUrl
             if (privacyPolicyUrl.isNotEmpty()) {
@@ -115,11 +116,11 @@ class TimerActivity :
                 intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                 startActivity(intent)
             } else {
-                Toast.makeText(
-                    this, getString(R.string.privacy_policy_offline),
-                    Toast.LENGTH_SHORT
-                )
-                    .show()
+                Snackbar.make(
+                    findViewById(R.id.frame),
+                    R.string.privacy_policy_offline,
+                    Snackbar.LENGTH_SHORT
+                ).show()
             }
         }
     }

--- a/app/src/main/java/com/imaginaryrhombus/proctimer/ui/timer/TimerFragment.kt
+++ b/app/src/main/java/com/imaginaryrhombus/proctimer/ui/timer/TimerFragment.kt
@@ -7,10 +7,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
-import android.widget.Toast
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
+import com.google.android.material.snackbar.Snackbar
 import com.imaginaryrhombus.proctimer.R
 import com.imaginaryrhombus.proctimer.databinding.TimerFragmentBinding
 import com.imaginaryrhombus.proctimer.ui.timerpicker.TimerPickerFragment
@@ -91,21 +91,21 @@ class TimerFragment : Fragment() {
 
         addButton.setOnClickListener {
             viewModel.addTimer {
-                Toast.makeText(
-                    context,
-                    getString(R.string.cannot_add_more_timer), Toast.LENGTH_SHORT
-                )
-                    .show()
+                Snackbar.make(
+                    requireView(),
+                    R.string.cannot_add_more_timer,
+                    Snackbar.LENGTH_SHORT
+                ).show()
             }
         }
 
         removeButton.setOnClickListener {
             viewModel.removeTimer {
-                Toast.makeText(
-                    context,
-                    getString(R.string.cannot_delete_last_timer), Toast.LENGTH_SHORT
-                )
-                    .show()
+                Snackbar.make(
+                    requireView(),
+                    R.string.cannot_delete_last_timer,
+                    Snackbar.LENGTH_SHORT
+                ).show()
             }
         }
 

--- a/app/src/main/res/layout/timer_activity.xml
+++ b/app/src/main/res/layout/timer_activity.xml
@@ -30,9 +30,12 @@
             android:id="@+id/frame"
             android:layout_width="0dp"
             android:layout_height="0dp"
-            app:layout_constraintTop_toBottomOf="@+id/toolbar" app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" android:layout_marginTop="4dp"
-            app:layout_constraintBottom_toBottomOf="parent"/>
+            android:layout_marginTop="4dp"
+            android:layout_marginBottom="48dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/toolbar" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
他の Activity やアプリにまたがって通知が必要なものがなく、むしろほかのアプリの上に重なってしまって邪魔になることのほうが多かったので、アプリ内でユーザーに対してのお知らせが完結する SnackBar を使用するよう変更