### PR TITLE
CircleCI でビルドが通らない問題の暫定対処

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,8 @@ defaults: &defaults
   docker:
     - image: circleci/android:api-28
   environment:
-    GRADLE_OPTS: -Dorg.gradle.daemon=false -Xms2g -Xmx2g
+    JAVA_OPTS: -Xmx1536m
+    GRADLE_OPTS: '-Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xmx1536m -XX:+HeapDumpOnOutOfMemoryError"'
 
 jobs:
     checkout:

--- a/Dangerfile
+++ b/Dangerfile
@@ -8,5 +8,5 @@ warn("PR is classed as Work in Progress") if github.pr_title.include? "[WIP]"
 
 # ktlint
 checkstyle_format.base_path = Dir.pwd
-checkstyle_format.report 'app/build/reports/ktlint/ktlintMainCheck.xml'
-checkstyle_format.report 'app/build/reports/ktlint/ktlintTestCheck.xml'
+checkstyle_format.report 'app/build/reports/ktlint/ktlintMainSourceSetCheck/ktlintMainSourceSetCheck.xml'
+checkstyle_format.report 'app/build/reports/ktlint/ktlintTestSourceSetCheck/ktlintTestSourceSetCheck.xml'


### PR DESCRIPTION
1.5Gまでにメモリを制限